### PR TITLE
zsh-vim-mode: init at 2021-03-21

### DIFF
--- a/pkgs/zsh/default.nix
+++ b/pkgs/zsh/default.nix
@@ -5,4 +5,5 @@
   vi-increment = import ./vi-increment.nix;
   vi-motions = import ./vi-motions.nix;
   vi-quote = import ./vi-quote.nix;
+  vim-mode = import ./vim-mode.nix;
 }

--- a/pkgs/zsh/vim-mode.nix
+++ b/pkgs/zsh/vim-mode.nix
@@ -1,0 +1,20 @@
+{ buildZshPlugin, lib, fetchFromGitHub }:
+
+buildZshPlugin rec {
+  pname = "zsh-vim-mode";
+  version = "2021-03-21";
+
+  src = fetchFromGitHub {
+    owner = "softmoth";
+    repo = pname;
+    rev = "1f9953b7d6f2f0a8d2cb8e8977baa48278a31eab";
+    sha256 = "1i79rrv22mxpk3i9i1b9ykpx8b4w93z2avck893wvmaqqic89vkb";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/softmoth/zsh-vim-mode";
+    description = "Friendly bindings for ZSH's vi mode";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
This zsh plugin seems relatively competent and is compatible with evil-registers, unlike zsh-vi-mode (since that reimplements all of vimode).